### PR TITLE
Fix UnicodeDecodeError in building package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,8 @@ with Path("requirements.txt").open(mode="r") as requirements_txt:
         str(requirement) for requirement in parse_requirements(requirements_txt)
     ]
 
-with open("README.md", "r") as f:
-    long_description = f.read()
+with Path("README.md").open(mode="r", encoding="utf-8") as readme_md:
+    long_description = readme_md.read()
 
 setup(
     name="pytest-pyppeteer",

--- a/src/pytest_pyppeteer/plugin.py
+++ b/src/pytest_pyppeteer/plugin.py
@@ -47,7 +47,7 @@ def pytest_addoption(
         "--nptp",
         "--new-pyppeteer-test-project",
         dest="nptp",
-        type=str,
+        type=Path,
         action="store",
         metavar="path",
         help="Create a new pyppeteer test project in the given path.",
@@ -56,9 +56,9 @@ def pytest_addoption(
 
 @pytest.mark.tryfirst
 def pytest_cmdline_main(config: conf.Config) -> Optional[Union[pytest.ExitCode, int]]:
-    nptp: str = config.getoption("nptp")
-    if nptp:
-        create_new_pyppeteer_project(nptp)
+    nptp_path: Optional[Path] = config.getoption("nptp")
+    if nptp_path:
+        create_new_pyppeteer_project(nptp_path)
         return pytest.ExitCode.OK
 
 

--- a/src/pytest_pyppeteer/utils.py
+++ b/src/pytest_pyppeteer/utils.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 
-def create_new_pyppeteer_project(nptp: str) -> None:
+def create_new_pyppeteer_project(nptp: Path) -> None:
     path: Path = Path(nptp)
     desc_dir: Path = path / "desc"
     desc_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Read long_description in utf-8 format and use Path directly as the parameter type for "--nptp" option.



