### PR TITLE
:lock: update lxml version.(>= 4.6.2)

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,45 +1,40 @@
--i https://mirrors.aliyun.com/pypi/simple/
--e .
 alabaster==0.7.12
 appdirs==1.4.4
-atomicwrites==1.4.0; sys_platform == 'win32'
-attrs==20.2.0
-babel==2.8.0
-certifi==2020.6.20
-chardet==3.0.4
-colorama==0.4.3; sys_platform == 'win32'
+attrs==20.3.0
+Babel==2.9.0
+certifi==2020.12.5
+chardet==4.0.0
 cssselect==1.1.0
 docutils==0.16
 idna==2.10
 imagesize==1.2.0
-iniconfig==1.0.1
-jinja2==2.11.2
-lxml==4.5.2
-markupsafe==1.1.1
-more-itertools==8.5.0
-packaging==20.4
+iniconfig==1.1.1
+Jinja2==2.11.2
+lxml==4.6.2
+MarkupSafe==1.1.1
+packaging==20.8
 pluggy==0.13.1
-py==1.9.0
-pydantic==1.6.1
+py==1.10.0
+pydantic==1.7.3
 pyee==7.0.4
-pygments==2.7.1
+Pygments==2.7.3
 pyparsing==2.4.7
 pyppeteer==0.2.2
+pytest==6.2.1
 pytest-asyncio==0.14.0
-pytest==6.0.2
-pytz==2020.1
-requests==2.24.0
-six==1.15.0
+-e git+https://github.com/luizyao/pytest-pyppeteer.git@08d944ff299a7225533ec4fa38443c448840f485#egg=pytest_pyppeteer
+pytz==2020.4
+requests==2.25.1
 snowballstemmer==2.0.0
+Sphinx==3.4.0
 sphinx-rtd-theme==0.5.0
-sphinx==3.2.1
 sphinxcontrib-applehelp==1.0.2
 sphinxcontrib-devhelp==1.0.2
 sphinxcontrib-htmlhelp==1.0.3
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.4
-toml==0.10.1
-tqdm==4.49.0
-urllib3==1.25.10
+toml==0.10.2
+tqdm==4.54.1
+urllib3==1.26.2
 websockets==8.1


### PR DESCRIPTION
CVE-2020-27783
moderate severity
Vulnerable versions: < 4.6.2
Patched version: 4.6.2
A XSS vulnerability was discovered in python-lxml's clean module. The module's parser didn't properly imitate browsers, which caused different behaviors between the sanitizer and the user's page. A remote attacker could exploit this flaw to run arbitrary HTML/JS code.