### PR TITLE
build: Project URLs for PyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,12 @@ description = "A plugin to run pyppeteer in pytest"
 authors = ["Luiz Yao <luizyao@163.com>"]
 readme = "README.md"
 license = "MIT"
+homepage = "https://github.com/luizyao/pytest-pyppeteer/"
+
+[tool.poetry.urls]
+"Bug Tracker" = "https://github.com/luizyao/pytest-pyppeteer/issues"
+Documentation = "https://github.com/luizyao/pytest-pyppeteer/blob/dev/README.md"
+Repository = "https://github.com/luizyao/pytest-pyppeteer/"
 
 [tool.poetry.plugins]
 


### PR DESCRIPTION
When published with `poetry build` this will give links on the PyPI homepage at https://pypi.org/project/pytest-pyppeteer/

![image](https://user-images.githubusercontent.com/26336/160714312-b829ddaf-68ff-430e-8f1c-cee8b4185e37.png)
